### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,8 @@ on: [push, pull_request]
 jobs:
   lint:
     name: Check lint
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/chrisroat/pyrcv/security/code-scanning/3](https://github.com/chrisroat/pyrcv/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the `lint` job. Since the job only requires read access to the repository contents, we will set `contents: read` as the permission. This ensures that the job has the least privilege necessary to perform its tasks.

The changes will be made in the `.github/workflows/ci.yml` file, specifically within the `lint` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
