### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,8 @@ jobs:
 
   test:
     name: Run tests
+    permissions:
+      contents: read
     runs-on: ubuntu-latest
     strategy:
       matrix:


### PR DESCRIPTION
Potential fix for [https://github.com/chrisroat/pyrcv/security/code-scanning/4](https://github.com/chrisroat/pyrcv/security/code-scanning/4)

To fix the issue, add a `permissions` block to the `test` job. Since the job only needs to read repository contents (e.g., to check out the code), the minimal required permission is `contents: read`. This change ensures that the job does not inherit unnecessary permissions from the repository's default settings.

The `permissions` block should be added directly under the `test` job definition, on line 28, to explicitly limit the permissions of the `GITHUB_TOKEN`.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
