### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
       - lint
       - test
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Potential fix for [https://github.com/chrisroat/pyrcv/security/code-scanning/5](https://github.com/chrisroat/pyrcv/security/code-scanning/5)

To fix the issue, we will add an explicit `permissions` block to the "Build distribution" job. Since this job only creates distribution packages and uploads them as artifacts, it does not require write access to the repository. The minimal required permission is `contents: read`. This change will ensure that the job has the least privilege necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
